### PR TITLE
Add instructions for AWS and Google Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,21 +42,21 @@ Then, you'll need to trigger a new Heroku deployment (see [Deployment](#Deployme
 
 Morpheme uses the Google Cloud Text-to-Speech and Natural Language APIs to generate audio from text. The resulting audio files are stored on Amazon S3.
 
-You will need a Google Cloud as well as an AWS Account to setup the application and configure them according to the steps below.
+You will need both a Google Cloud account and an AWS account to setup the application, they should be configured according to the steps below.
 
 ### AWS
 
-- [Log into the AWS S3 Console](https://console.aws.amazon.com/s3/).
+- [Login to the AWS S3 Console](https://console.aws.amazon.com/s3/).
 - [Create an S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html).
 - [Create an AWS Access Key](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html) via the [Security Credentials Page](https://console.aws.amazon.com/iam/home?#security_credential) of the AWS Console and store it in a secure place.
 
 ### Google Cloud
 
-- [Log into the Google Cloud Console](https://console.cloud.google.com).
+- [Login to the Google Cloud Console](https://console.cloud.google.com).
 - [Create a new Service Account/Project](https://cloud.google.com/iam/docs/creating-managing-service-accounts) for your instance of Morpheme from the [Service Accounts Page](https://console.cloud.google.com/iam-admin/serviceaccounts) of the Google Cloud Console.
-- [Enable](https://cloud.google.com/service-usage/docs/enable-disable) the [Cloud Text-to-Speech](https://console.cloud.google.com/marketplace/product/google/texttospeech.googleapis.com) and [Cloud Natural Language](https://console.cloud.google.com/marketplace/product/google/language.googleapis.com) API for the service account you just created.
+- [Enable](https://cloud.google.com/service-usage/docs/enable-disable) the [Cloud Text-to-Speech](https://console.cloud.google.com/marketplace/product/google/texttospeech.googleapis.com) and [Cloud Natural Language](https://console.cloud.google.com/marketplace/product/google/language.googleapis.com) APIs for the service account you just created.
 - [Create a Service Account Access Key](https://cloud.google.com/docs/authentication/getting-started) and store the JSON key file in a secure place.
 
-The Google Cloud and AWS credentials need to be added as Config Variables to the app for it to be deployed successfully. You'll be prompted to enter them in Herokus's "Create New App" interface after clicking the "Deploy to Heroku" button.
+The Google Cloud and AWS credentials need to be added as Config Variables to the app for it to be deployed successfully. You'll be prompted to enter them in Heroku's "Create New App" interface after clicking the "Deploy to Heroku" button.
 
 To connect the app to S3 the 'Access Key ID', 'Secret Access Key' and the name of the bucket need to be entered in Heroku's setup form. To use Google Cloud APIs the contents of the JSON key file need to be copied in the corresponding field to the same form.


### PR DESCRIPTION
This PR adds some basic information about how to setup and configure AWS and Google Cloud to work with Morpheme. I had to hunt down this information while setting up Morpheme for myself. I think it will come in handy for everyone not working with Google Cloud and AWS on a regular basis.