### PR TITLE
Chore: use new env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/diesdasdigital/morpheme:v0.0.13
+FROM ghcr.io/diesdasdigital/morpheme:v1.0.0
 
 COPY replacements.json .
 COPY config.json .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,4 @@ FROM ghcr.io/diesdasdigital/morpheme:v0.0.13
 COPY replacements.json .
 COPY config.json .
 COPY transitions/ transitions/
-COPY google-credentials.json .
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ To spin up your own local instance of this application, follow these instruction
 
 1. Ensure that you have [`docker`](https://docs.docker.com/get-docker/) and [`docker-compose`](https://docs.docker.com/compose/install/) installed.
 2. Create a `.env` file at the project root, using [`.env.sample`](https://github.com/diesdasdigital/morpheme/blob/main/.env.sample) as a template. Fill in all of the secret values.
-3. Create a `google-credentials.json` file at the project root, using your Google Service account credentials.
-4. Optionally, edit `config.json` if you wish to override any configuration defaults. Refer to [`docs/CONFIG.md`](https://github.com/diesdasdigital/morpheme/blob/main/docs/CONFIG.md) for more details.
-5. Optionally, edit `replacements.json` if you wish to augment the built-in replacements. Refer to [`docs/REPLACEMENTS.md`](https://github.com/diesdasdigital/morpheme/blob/main/docs/REPLACEMENTS.md) for more details.
-6. Start the application with `docker-compose up --build`.
+3. Optionally, edit `config.json` if you wish to override any configuration defaults. Refer to [`docs/CONFIG.md`](https://github.com/diesdasdigital/morpheme/blob/main/docs/CONFIG.md) for more details.
+4. Optionally, edit `replacements.json` if you wish to augment the built-in replacements. Refer to [`docs/REPLACEMENTS.md`](https://github.com/diesdasdigital/morpheme/blob/main/docs/REPLACEMENTS.md) for more details.
+5. Start the application with `docker-compose up --build`.
 
 ## Upgrading to a new Morpheme release
 

--- a/app.json
+++ b/app.json
@@ -20,7 +20,12 @@
       "description": "A secret token for authenticating protected endpoints",
       "generator": "secret"
     },
-    "GOOGLE_CREDENTIALS": {
+    "GOOGLE_SERVICE_ACCOUNT_CLIENT_EMAIL": {
+      "description": "Extract the value for `client_email` from your Google Service Account JSON credentials file.",
+      "required": true
+    },
+    "GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY": {
+      "description": "Extract the value for `private_key` from your Google Service Account JSON credentials file.",
       "required": true
     },
     "LOG_LEVEL": {

--- a/app.json
+++ b/app.json
@@ -1,10 +1,5 @@
 {
   "stack": "container",
-  "buildpacks": [
-    {
-      "url": "https://github.com/elishaterada/heroku-google-application-credentials-buildpack"
-    }
-  ],
   "env": {
     "AWS_ACCESS_KEY_ID": {
       "required": true


### PR DESCRIPTION
Morpheme has had a new major version published, and here are the necessary updates to reflect the breaking changes. The breaking changes were that there are two new ENV variables to replace the `google-credentials.json` authorisation mechanism, which really just encouraged dangerously committing that file to source-control.